### PR TITLE
Introduce forEach multi-stage domain specific language

### DIFF
--- a/laser/openmp.nim
+++ b/laser/openmp.nim
@@ -243,28 +243,25 @@ template omp_chunks*(
     remainder = omp_size mod nb_chunks
     thread_id = omp_get_thread_num()
 
-    # Instead of dividing 40 work items on 12 cores into:
-    # 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 7 = 3*11 + 7 = 40
-    # the following scheme will divide into
-    # 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3 = 4*4 + 3*8 = 40
-    #
-    # This is compliant with OpenMP spec (page 60)
-    # http://www.openmp.org/mp-documents/openmp-4.5.pdf
-    # "When no chunk_size is specified, the iteration space is divided into chunks
-    # that are approximately equal in size, and at most one chunk is distributed to
-    # each thread. The size of the chunks is unspecified in this case."
-    # ---> chunks are the same ±1
+  # Instead of dividing 40 work items on 12 cores into:
+  # 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 7 = 3*11 + 7 = 40
+  # the following scheme will divide into
+  # 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3 = 4*4 + 3*8 = 40
+  #
+  # This is compliant with OpenMP spec (page 60)
+  # http://www.openmp.org/mp-documents/openmp-4.5.pdf
+  # "When no chunk_size is specified, the iteration space is divided into chunks
+  # that are approximately equal in size, and at most one chunk is distributed to
+  # each thread. The size of the chunks is unspecified in this case."
+  # ---> chunks are the same ±1
 
-    `chunk_offset`{.inject.} = block:
-      if thread_id < remainder:
-        (base_chunk_size + 1) * thread_id
-      else:
-        base_chunk_size * thread_id + remainder
-    `chunk_size`{.inject.} = block:
-      if thread_id < remainder:
-        base_chunk_size + 1
-      else:
-        base_chunk_size
+  var `chunk_offset`{.inject.}, `chunk_size`{.inject.}: Natural
+  if thread_id < remainder:
+    chunk_offset = (base_chunk_size + 1) * thread_id
+    chunk_size = base_chunk_size + 1
+  else:
+    chunk_offset = base_chunk_size * thread_id + remainder
+    chunk_size = base_chunk_size
 
   block: body
 

--- a/laser/strided_iteration/foreach.nim
+++ b/laser/strided_iteration/foreach.nim
@@ -108,10 +108,11 @@ template forEachContiguousTemplate(use_openmp: static bool){.dirty.} =
     params, loopBody, values, aliases, raw_ptrs: NimNode
     aliases_stmt, raw_ptrs_stmt, test_shapes: NimNode
 
+  params = args
+  loopBody = params.pop()
+
   initForEach(
-        args,
         params,
-        loopBody,
         values, aliases, raw_ptrs,
         aliases_stmt, raw_ptrs_stmt,
         test_shapes
@@ -136,10 +137,11 @@ template forEachStridedTemplate(use_openmp: static bool){.dirty.} =
     params, loopBody, values, aliases, raw_ptrs: NimNode
     aliases_stmt, raw_ptrs_stmt, test_shapes: NimNode
 
+  params = args
+  loopBody = params.pop()
+
   initForEach(
-        args,
         params,
-        loopBody,
         values, aliases, raw_ptrs,
         aliases_stmt, raw_ptrs_stmt,
         test_shapes
@@ -164,10 +166,11 @@ template forEachTemplate(use_openmp: static bool) {.dirty.} =
     params, loopBody, values, aliases, raw_ptrs: NimNode
     aliases_stmt, raw_ptrs_stmt, test_shapes: NimNode
 
+  params = args
+  loopBody = params.pop()
+
   initForEach(
-        args,
         params,
-        loopBody,
         values, aliases, raw_ptrs,
         aliases_stmt, raw_ptrs_stmt,
         test_shapes

--- a/laser/strided_iteration/foreach_common.nim
+++ b/laser/strided_iteration/foreach_common.nim
@@ -77,7 +77,7 @@ proc initForEach*(
     test_shapes.add quote do:
       assert `alias0`.shape == `alias_i`.shape
 
-template stridedVarsSetup*(){.dirty.} =
+template stridedVarsSetup*(): untyped {.dirty.} =
   for i, alias in aliases:
     let iter_pos_i = gensym(nskVar, "iter" & $i & "_pos_")
     iter_pos.add iter_pos_i
@@ -90,7 +90,7 @@ template stridedVarsSetup*(){.dirty.} =
       `iter_pos_i` -= `alias`.strides[`k`] * (`alias`.shape[`k`]-1)
 
 
-template stridedChunkOffset*(){.dirty.} =
+template stridedChunkOffset*(): untyped {.dirty.} =
   quote do:
     if `chunk_offset` != 0:
       var accum_size = 1
@@ -99,7 +99,7 @@ template stridedChunkOffset*(){.dirty.} =
         `iter_start_offset`
         accum_size *= `alias0`.shape[`j`]
 
-template stridedBodyTemplate*(){.dirty.} =
+template stridedBodyTemplate*(): untyped {.dirty.} =
   quote do:
     # Initialisation
     `init_strided_iteration`

--- a/laser/strided_iteration/foreach_common.nim
+++ b/laser/strided_iteration/foreach_common.nim
@@ -14,17 +14,13 @@ template isVar[T: object](x: T): bool =
   compiles(addr(x))
 
 proc initForEach*(
-        args: NimNode,
-        params: var NimNode,
-        loopBody: var NimNode,
+        params: NimNode,
         values, aliases, raw_ptrs: var NimNode,
         aliases_stmt, raw_ptrs_stmt: var NimNode,
         test_shapes: var NimNode
       ) =
 
   ### Parse the input
-  params = args
-  loopBody = params.pop()
   values = nnkBracket.newTree()
   var tensors = nnkBracket.newTree()
 

--- a/laser/strided_iteration/foreach_common.nim
+++ b/laser/strided_iteration/foreach_common.nim
@@ -101,20 +101,20 @@ template stridedChunkOffset*(){.dirty.} =
 
 template stridedBodyTemplate*(){.dirty.} =
   quote do:
-      # Initialisation
-      `init_strided_iteration`
+    # Initialisation
+    `init_strided_iteration`
 
-      # Iterator loop
-      for _ in 0 ..< `chunk_size`:
-        # Apply computation
-        `body`
+    # Iterator loop
+    for _ in 0 ..< `chunk_size`:
+      # Apply computation
+      `body`
 
-        # Next position
-        for `k` in countdown(`alias0`.rank - 1, 0):
-          if `coord`[`k`] < `alias0`.shape[`k`] - 1:
-            `coord`[`k`] += 1
-            `increment_iter_pos`
-            break
-          else:
-            `coord`[`k`] = 0
-            `apply_backstrides`
+      # Next position
+      for `k` in countdown(`alias0`.rank - 1, 0):
+        if `coord`[`k`] < `alias0`.shape[`k`] - 1:
+          `coord`[`k`] += 1
+          `increment_iter_pos`
+          break
+        else:
+          `coord`[`k`] = 0
+          `apply_backstrides`

--- a/laser/strided_iteration/foreach_common.nim
+++ b/laser/strided_iteration/foreach_common.nim
@@ -17,7 +17,6 @@ proc initForEach*(
         args: NimNode,
         params: var NimNode,
         loopBody: var NimNode,
-        omp_params: var NimNode,
         values, aliases, raw_ptrs: var NimNode,
         aliases_stmt, raw_ptrs_stmt: var NimNode,
         test_shapes: var NimNode
@@ -46,8 +45,6 @@ proc initForEach*(
         tensors.add arg[0][1]
       else:
         syntaxError()
-    elif getType(arg) is tuple:
-      omp_params = arg
     else:
       syntaxError()
 

--- a/laser/strided_iteration/foreach_staged.nim
+++ b/laser/strided_iteration/foreach_staged.nim
@@ -1,0 +1,169 @@
+# Laser
+# Copyright (c) 2018 Mamy André-Ratsimbazafy
+# Distributed under the Apache v2 License (license terms are at http://www.apache.org/licenses/LICENSE-2.0).
+# This file may not be copied, modified, or distributed except according to those terms.
+
+# This file implements the forEachStaged macro which allows multi-stage parallel for loop
+# on a variadic number of tensors
+
+import
+  macros,
+  ./foreach_common,
+  ../private/ast_utils,
+  ../openmp
+export omp_suffix
+
+template omp_parallel_threshold(size, threshold: Natural, body: untyped) =
+  {.emit: "#pragma omp parallel if (`size` < `threshold`)".}
+  block: body
+
+proc forEachStagedContiguousImpl(
+  values, raw_ptrs, size, loopBody: NimNode,
+  use_simd: static bool,
+  ): NimNode =
+  # Build the body of a contiguous iterator
+  # Whether this is parallelized or not should be
+  # handled at a higher level
+
+  let index = newIdentNode("contiguousIndex_")
+  var elems_contiguous = nnkBracket.newTree()
+  for raw_ptr in raw_ptrs:
+    elems_contiguous.add nnkBracketExpr.newTree(raw_ptr, index)
+
+  let body = loopBody.replaceNodes(
+                  replacements = elems_contiguous,
+                  to_replace = values
+                  )
+
+  result = getAST(
+    omp_for,
+    index, size, use_simd, loopBody
+  )
+
+proc forEachStagedStridedImpl(
+  values, aliases,
+  raw_ptrs, size,
+  loopBody: NimNode,
+  use_openmp: static bool
+  ): NimNode =
+  # Build the parallel body of a strided iterator
+
+  var iter_pos = nnkBracket.newTree()
+  var init_strided_iteration = newStmtList()
+  var iter_start_offset = newStmtList()
+  var increment_iter_pos = newStmtList()
+  var apply_backstrides = newStmtList()
+
+  let
+    alias0 = aliases[0]
+    coord = genSym(nskVar, "coord_")
+    j = genSym(nskForVar, "j_mem_offset_") # Setting the start offset of each tensor iterator during init
+    k = genSym(nskForVar, "k_next_elem_")  # Computing the next element in main body loop
+    chunk_offset = newIdentNode("chunk_offset_")
+    chunk_size =  if use_openmp: newIdentNode("chunk_size_")
+                  else: size
+
+  init_strided_iteration.add quote do:
+    var `coord` {.align_variable.}: array[LASER_MEM_ALIGN, int]
+
+  stridedVarsSetup()
+
+  # Now add the starting memory offset to the init
+  if use_openmp:
+    init_strided_iteration.add stridedChunkOffset()
+
+  var elems_strided = nnkBracket.newTree()
+  for i, raw_ptr in raw_ptrs:
+    elems_strided.add nnkBracketExpr.newTree(raw_ptr, iter_pos[i])
+
+  let body = loopBody.replaceNodes(replacements = elems_strided, to_replace = values)
+  let stridedBody = stridedBodyTemplate()
+
+  if use_openmp:
+    result = getAST(
+      omp_chunks,
+      size, chunk_offset, chunk_size,
+      stridedBody
+    )
+  else:
+    result = stridedBody
+
+template forEachStagedSimpleTemplate(contiguous: static bool){.dirty.} =
+  let body =  if contiguous:
+                forEachStagedContiguousImpl(
+                  values, raw_ptrs, size, in_loop_body, use_simd
+                )
+              else:
+                forEachStagedStridedImpl(
+                  values, aliases, raw_ptrs, size, in_loop_body, use_openmp
+                )
+  let alias0 = aliases[0]
+
+  if use_openmp:
+    result = quote do:
+      block:
+        `aliases_stmt`
+        `test_shapes`
+        `raw_ptrs_stmt`
+        let `size` = `alias0`.size
+        `before_loop_body`
+        `body`
+        `after_loop_body`
+
+  else:
+    result = quote do:
+      block:
+        `aliases_stmt`
+        `test_shapes`
+        `raw_ptrs_stmt`
+        let `size` = `alias0`.size
+        omp_parallel_threshold(size, omp_threshold):
+          `before_loop_body`
+          `body`
+          `after_loop_body`
+
+template forEachStagedTemplate(){.dirty.} =
+  let contiguous_body = forEachStagedContiguousImpl(
+                          values, raw_ptrs, size, in_loop_body, use_simd
+                        )
+  let strided_body =  forEachStagedStridedImpl(
+                        values, aliases, raw_ptrs, size, in_loop_body, use_openmp
+                      )
+
+  let alias0 = aliases[0]
+  var test_C_Contiguous = newCall(ident"is_C_contiguous", alias0)
+  for i in 1 ..< aliases.len:
+    test_C_Contiguous = newCall(
+                          ident"and",
+                          test_C_Contiguous,
+                          newCall(ident"is_C_contiguous", aliases[i])
+                        )
+  if use_openmp:
+    result = quote do:
+      block:
+        `aliases_stmt`
+        `test_shapes`
+        `raw_ptrs_stmt`
+        let `size` = `alias0`.size
+        `before_loop_body`
+        if `test_C_Contiguous`:
+          `contiguous_body`
+        else:
+          `strided_body`
+        `after_loop_body`
+
+  else:
+    result = quote do:
+      block:
+        `aliases_stmt`
+        `test_shapes`
+        `raw_ptrs_stmt`
+        let `size` = `alias0`.size
+        let is_C_contiguous = `test_C_Contiguous`
+        omp_parallel_threshold(size, omp_threshold):
+          `before_loop_body`
+          if is_C_contiguous:
+            `contiguous_body`
+          else:
+            `strided_body`
+          `after_loop_body`


### PR DESCRIPTION
The goal is to remove `reduceEach` which was a workaround for Nim limitations in https://github.com/nim-lang/Nim/issues/9490. This was fixed in https://github.com/nim-lang/Nim/pull/9493.

The domain specific language should allow a "multi-stage" parallel section with a variadic for loop similar to:

```Nim
proc reduction_localvar(s: seq[int]): int =
  omp_parallel:
    ### initialization
    var local_sum = 0

    ### for loop
    for i in `||`(0, s.len-1, "for"):
      local_sum += s[i]

    ### Finalization
    omp_critical:
      result += local_sum
```

Currently `reduceEach` require `nb_chunks` to be passed as params to `omp_parallel_chunks` (https://github.com/numforge/laser/commit/9ba351a263bb03a0930e90fdb358b59d6bb3ae0f) but this workaround was removed (https://github.com/numforge/laser/commit/dbd483c263d456102561465f358f6384039fe443). Furthermore `reduceEach` requires allocation of a temporary seq while the DSL would leave partial_sums' tradeoffs at the user discretion:
  - padding avoids false sharing and locks but requires temporary seq allocation which might be slow or restricted (embedded devices) and will require an extra pass on the temporary seq.
  - OpenMP critical requires locking
  - OpenMP atomic is only supported for a narrow subset of operations
  - Nim builtin atomics

Parallel reduction on multiple tensors is used for vector dot product and **all loss functions**.

Also closes #3