### PR TITLE
Improve gemm threading

### DIFF
--- a/benchmarks/gemm/gemm_bench_float32.nim
+++ b/benchmarks/gemm/gemm_bench_float32.nim
@@ -238,7 +238,7 @@ when isMainModule:
 
     block:
       var error = mean_relative_error(challenger, reference)
-      doAssert error <= 1e-3'f32, $error
+      doAssert error <= 1.5e-2'f32, $error
 
 # Seems like my original Arraymancer BLAS has false sharing issue
 # FYI Apple accelerate is about 117~122GFLOP/s on my machine.

--- a/laser/openmp.nim
+++ b/laser/openmp.nim
@@ -344,16 +344,28 @@ template omp_master*(body: untyped): untyped =
   {.emit: "#pragma omp master".}
   block: body
 
+template omp_single*(body: untyped): untyped =
+  {.emit: "#pragma omp single".}
+  block: body
+
 template omp_barrier*(): untyped =
   {.emit: "#pragma omp barrier".}
+
+template omp_task*(annotation: static string, body: untyped): untyped =
+  {.emit: "#pragma omp task " & annotation.}
+  block: body
+
+template omp_taskwait*(): untyped =
+  {.emit: "#pragma omp taskwait".}
 
 template omp_taskloop*(
     index: untyped,
     length: Natural,
+    annotation: static string,
     body: untyped
   ) =
   ## OpenMP taskloop
-  const omp_annotation = "taskloop"
+  const omp_annotation = "taskloop " & annotation
   for `index`{.inject.} in `||`(0, length-1, omp_annotation):
     block: body
 

--- a/laser/primitives/matrix_multiplication/gemm.nim
+++ b/laser/primitives/matrix_multiplication/gemm.nim
@@ -69,7 +69,9 @@ proc gebp_mkernel[T; ukernel: static MicroKernel](
 
   # #####################################
   # 4. for jr = 0,...,nc−1 in steps of nr
-  omp_for(jrb, tiles.jr_num_nr_tiles, use_simd = false, nowait = true):
+  # debugecho "jr_num_nr_tiles: ", tiles.jr_num_nr_tiles
+  for jrb in 0||(tiles.jr_num_nr_tiles - 1):
+    # debugecho "jrb: ", jrb
     let jr = jrb * NR
     let nr = min(nc - jr, NR)                        # C[ic:ic+mc, jc+jr:jc+jr+nr]
 

--- a/laser/primitives/matrix_multiplication/gemm.nim
+++ b/laser/primitives/matrix_multiplication/gemm.nim
@@ -69,7 +69,7 @@ proc gebp_mkernel[T; ukernel: static MicroKernel](
 
   # #####################################
   # 4. for jr = 0,...,nc−1 in steps of nr
-  omp_for(jrb, tiles.jr_num_nr_tiles - 1, use_simd = false, nowait = true):
+  omp_for(jrb, tiles.jr_num_nr_tiles, use_simd = false, nowait = true):
     let jr = jrb * NR
     let nr = min(nc - jr, NR)                        # C[ic:ic+mc, jc+jr:jc+jr+nr]
 
@@ -83,7 +83,7 @@ proc gebp_mkernel[T; ukernel: static MicroKernel](
       prefetch(upanel_b, Read, ModerateTemporalLocality)
       let upanel_a = tiles.a + ir*kc
       prefetch(upanel_a, Read, ModerateTemporalLocality)
-
+      
       if nr == NR and mr == MR:
         # General case
         gebb_ukernel[T, ukernel](                    # GEBB microkernel + epilogue

--- a/laser/primitives/matrix_multiplication/gemm.nim
+++ b/laser/primitives/matrix_multiplication/gemm.nim
@@ -266,7 +266,7 @@ when isMainModule:
     # echo "result: ", res_ab
 
     doAssert res_ab == ab, $res_ab
-    # echo '\n'
+    echo "SUCCESS\n"
 
   block:
     let a = [[1.0, 2, 3],
@@ -293,7 +293,7 @@ when isMainModule:
     # echo "result: ", res_ab
 
     doAssert res_ab == ab, $res_ab
-    # echo '\n'
+    echo "SUCCESS\n"
 
   block:
     let a = [[1.0,2,3],
@@ -318,7 +318,7 @@ when isMainModule:
     # echo "result: ", res_ab
 
     doAssert res_ab == ab, $res_ab
-    # echo '\n'
+    echo "SUCCESS\n"
 
   block:
     # example from http://www.intmath.com/matrices-determinants/matrix-multiplication-examples.php
@@ -344,7 +344,7 @@ when isMainModule:
     # echo "result: ", res_ab
 
     doAssert res_ab == ab, $res_ab
-    # echo '\n'
+    echo "SUCCESS\n"
 
   block:
     # from http://www.calcul.com/show/calculator/matrix-multiplication_;5;5;5;5?matrix1=[[%225%22,%226%22,%225%22,%228%22],[%228%22,%222%22,%228%22,%228%22],[%220%22,%225%22,%224%22,%220%22],[%224%22,%220%22,%225%22,%226%22],[%224%22,%225%22,%220%22,%223%22]]&matrix2=[[%225%22,%223%22,%226%22,%220%22],[%225%22,%222%22,%223%22,%223%22],[%228%22,%228%22,%222%22,%220%22],[%227%22,%227%22,%220%22,%220%22]]&operator=*
@@ -377,7 +377,7 @@ when isMainModule:
     # echo "result: ", res_ab
 
     doAssert res_ab == ab, $res_ab
-    # echo '\n'
+    echo "SUCCESS\n"
 
   block:
     let a =  [[2, 4,  3,  1,  3,  1,  3,  1],
@@ -408,7 +408,7 @@ when isMainModule:
     # echo "result: ", res_ab
 
     doAssert res_ab == ab, $res_ab
-    # echo '\n'
+    echo "SUCCESS\n"
 
   block:
     let a =  [[2, 1],
@@ -445,7 +445,7 @@ when isMainModule:
     # echo "result: ",   res_ab
 
     doAssert res_ab == ab, $res_ab
-    # echo '\n'
+    echo "SUCCESS\n"
 
   block:
     # from http://www.calcul.com/show/calculator/matrix-multiplication?matrix1=[[%222%22,%224%22,%223%22,%221%22,%223%22,%221%22,%223%22,%221%22],[%221%22,%222%22,%221%22,%221%22,%222%22,%220%22,%224%22,%223%22],[%222%22,%220%22,%220%22,%223%22,%220%22,%224%22,%224%22,%221%22],[%221%22,%221%22,%224%22,%220%22,%223%22,%221%22,%223%22,%220%22],[%223%22,%224%22,%221%22,%221%22,%224%22,%222%22,%223%22,%224%22],[%222%22,%224%22,%220%22,%222%22,%223%22,%223%22,%223%22,%224%22],[%223%22,%220%22,%220%22,%223%22,%221%22,%224%22,%223%22,%221%22],[%224%22,%223%22,%222%22,%224%22,%221%22,%220%22,%220%22,%220%22]]&matrix2=[[%222%22,%222%22,%220%22,%224%22,%220%22,%220%22,%224%22,%222%22],[%222%22,%220%22,%220%22,%221%22,%221%22,%221%22,%223%22,%221%22],[%220%22,%222%22,%222%22,%220%22,%222%22,%222%22,%223%22,%223%22],[%220%22,%220%22,%221%22,%220%22,%224%22,%222%22,%224%22,%221%22],[%220%22,%220%22,%221%22,%223%22,%224%22,%222%22,%224%22,%222%22],[%224%22,%223%22,%224%22,%221%22,%224%22,%224%22,%220%22,%223%22],[%223%22,%223%22,%220%22,%222%22,%221%22,%222%22,%223%22,%223%22],[%222%22,%221%22,%222%22,%221%22,%222%22,%224%22,%224%22,%221%22]]&operator=*
@@ -491,4 +491,4 @@ when isMainModule:
     # echo "result: ",   res_ab
 
     doAssert res_ab == ab, $res_ab
-    # echo '\n'
+    echo "SUCCESS\n"

--- a/laser/primitives/matrix_multiplication/gemm_tiling.nim
+++ b/laser/primitives/matrix_multiplication/gemm_tiling.nim
@@ -65,6 +65,7 @@ type
     nb_scalars*: int # Ideally MicroKernel should be generic over T
     nb_vecs_nr*: int
     c_unit_stride*: bool # We can use SIMD for the epilogue of C has a unit_stride
+    pt*: int # Parallelization threshold
 
     # TODO: ARM support
     #   - https://github.com/nim-lang/Nim/issues/9679
@@ -123,6 +124,7 @@ const X86_regs: X86_FeatureMap = [
 func x86_ukernel*(cpu: CPUFeatureX86, T: typedesc, c_unit_stride: bool): MicroKernel =
   result.cpu_simd = cpu
   result.c_unit_stride = c_unit_stride
+  result.pt = 128
   when T is SomeFloat:
     result.nb_scalars = max(1, X86_vecsize_float[cpu] div T.sizeof)
   elif T is SomeInteger: # Integers
@@ -159,6 +161,9 @@ macro extract_nb_vecs_nr*(ukernel: static MicroKernel): untyped =
   result = newLit ukernel.nb_vecs_nr
 macro extract_c_unit_stride*(ukernel: static MicroKernel): untyped =
   result = newLit ukernel.c_unit_stride
+macro extract_pt*(ukernel: static MicroKernel): untyped =
+  result = newLit ukernel.pt
+
 
 # ############################################################
 #

--- a/laser/primitives/matrix_multiplication/gemm_tiling.nim
+++ b/laser/primitives/matrix_multiplication/gemm_tiling.nim
@@ -177,7 +177,7 @@ type Tiles*[T] = ref object
     # Nim doesn't support arbitrary increment with OpenMP
     # So we store indexing/edge case data in tiles for the parallelized loop
   ic_num_mc_tiles*: int   # For private L1-L2 and shared L3
-  # jr_num_nr_tiles*: int # For private L1 and shared L2 cache
+  jr_num_nr_tiles*: int   # For private L1 and shared L2 cache
 
   # Allocation data
     # TODO Save on cache line, use an aligned allocator to not track this
@@ -238,6 +238,7 @@ proc newTiles*(
   # Parallel config
   # Ic loop parallel means that each thread will share a panel B and pack a different A
   result.ic_num_mc_tiles = (M+result.mc-1) div result.mc
+  result.jr_num_nr_tiles = (result.nc+nr-1) div nr
 
   # Packing
   # During packing the max size is unroll_stop*kc+kc*LR, LR = MR or NR

--- a/laser/private/error_functions.nim
+++ b/laser/private/error_functions.nim
@@ -22,13 +22,13 @@ proc mean_relative_error*[T: SomeFloat](y, y_true: seq[T]): T {.inline.} =
 
   result = 0.T
   for i in 0 ..< y.len:
-    result += relative_error(y, y_true)
-  result / y.len
+    result += relative_error(y[i], y_true[i])
+  result = result / y.len.T
 
 proc mean_absolute_error*[T: SomeFloat](y, y_true: seq[T]): T {.inline.} =
   doAssert y.len == y_true.len
 
   result = 0.T
   for i in 0 ..< y.len:
-    result += absolute_error(y, y_true)
-  result / y.len
+    result += absolute_error(y[i], y_true[i])
+  result = result / y.len.T

--- a/research/matrix_multiplication_optimisation_resources.md
+++ b/research/matrix_multiplication_optimisation_resources.md
@@ -26,3 +26,9 @@ Very Small Matrices
 A Portable Compiler Approach,
     - http://www.cse.unsw.edu.au/~jingling/papers/cgo17.pdf
 - http://www.cs.utexas.edu/users/flame/pubs/bamarker_thesis.pdf
+
+## Implementations
+- Matmul with OpenMP tasks
+  https://www.openmp.org/wp-content/uploads/openmp-examples-4.5.0.pdf p78
+- Optimizing Matrix Multiplication on Xeon Phi
+  https://www.springer.com/cda/content/document/cda_downloaddocument/9783319064857-c9.pdf?SGWID=0-0-45-1471414-p176715535


### PR DESCRIPTION
And fix some bugs in the matmul result

```
Warmup: 0.9065 s, result 224 (displayed to avoid compiler optimizing warmup away)

A matrix shape: (M: 3840, N: 3840)
B matrix shape: (M: 3840, N: 3840)
Output shape: (M: 3840, N: 3840)
Required number of operations: 113246.208 millions
Required bytes:                  117.965 MB
Arithmetic intensity:            960.000 FLOP/byte
Theoretical peak single-core:    230.400 GFLOP/s
Theoretical peak multi:         4147.200 GFLOP/s
Make sure to not bench Apple Accelerate or the default Linux BLAS.

OpenBLAS benchmark
Collected 10 samples in 0.498 seconds
Average time: 49.239 ms
Stddev  time: 4.498 ms
Min     time: 47.776 ms
Max     time: 62.040 ms
Perf:         2299.923 GFLOP/s

Display result[0] to make sure it's not optimized away
950.1965942382812

Laser production implementation
Collected 10 samples in 0.463 seconds
Average time: 45.686 ms
Stddev  time: 7.577 ms
Min     time: 43.124 ms
Max     time: 67.247 ms
Perf:         2478.801 GFLOP/s

Display result[0] to make sure it's not optimized away
950.1968383789062
```

```
Warmup: 0.9066 s, result 224 (displayed to avoid compiler optimizing warmup away)

A matrix shape: (M: 1920, N: 1920)
B matrix shape: (M: 1920, N: 1920)
Output shape: (M: 1920, N: 1920)
Required number of operations: 14155.776 millions
Required bytes:                   29.491 MB
Arithmetic intensity:            480.000 FLOP/byte
Theoretical peak single-core:    230.400 GFLOP/s
Theoretical peak multi:         4147.200 GFLOP/s
Make sure to not bench Apple Accelerate or the default Linux BLAS.

OpenBLAS benchmark
Collected 10 samples in 0.082 seconds
Average time: 8.061 ms
Stddev  time: 4.966 ms
Min     time: 6.009 ms
Max     time: 21.936 ms
Perf:         1756.065 GFLOP/s

Display result[0] to make sure it's not optimized away
470.7781372070312

Laser production implementation
Collected 10 samples in 0.116 seconds
Average time: 11.490 ms
Stddev  time: 16.207 ms
Min     time: 6.277 ms
Max     time: 57.616 ms
Perf:         1232.053 GFLOP/s

Display result[0] to make sure it's not optimized away
470.778076171875
```