### PR TITLE
Lux refactor v3 - Frontend

### DIFF
--- a/laser/lux_compiler/core/lux_core_checks.nim
+++ b/laser/lux_compiler/core/lux_core_checks.nim
@@ -1,0 +1,60 @@
+# Laser
+# Copyright (c) 2018 Mamy André-Ratsimbazafy
+# Distributed under the Apache v2 License (license terms are at http://www.apache.org/licenses/LICENSE-2.0).
+# This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Internal
+  ./lux_types, ./lux_core_helpers
+
+# ###########################################
+#
+#                AST checks
+#
+# ###########################################
+
+# For composability, similar to Nim macros
+# and Lisp, every LuxNodes except literals are
+# seq[LuxNode]. That requires checking that the AST
+# is well formed.
+
+proc parseCheckBinOp*(node: LuxNode) =
+  assert node.kind == BinOp
+  assert node.len == 3
+  assert node[0].kind == BinOpKind
+  assert node[1].kind in LuxExpr
+  assert node[2].kind in LuxExpr
+
+proc parseAssign*(node: LuxNode) =
+  assert node.kind == Assign
+  assert node.len == 2
+  assert node[0].kind == Func
+  assert node[1].kind in LuxExpr
+
+proc parseAccess*(node: LuxNode) =
+  assert node.kind == Access
+  assert node[0].kind == Func
+
+  for i in 1 ..< node.children.len:
+    assert node[i] in {
+      IntImm, IntParam, Domain,
+      BinOp
+    }
+
+proc parseShape*(node: LuxNode) =
+  assert node.kind == Shape
+  assert node.len == 2
+  assert node[0].kind == Func
+  assert node[1].kind == IntImm
+
+proc parseAffineFor*(node: LuxNode) =
+  assert node.kind == AffineFor
+  assert node.len == 2
+  assert node[0].kind == Domain
+  assert node[1].kind == Statement
+
+proc parseAffineIf*(node: LuxNode) =
+  assert node.kind == AffineIf
+  assert node.len == 2
+  assert node[0].kind in LuxExpr
+  assert node[1].kind == Statement

--- a/laser/lux_compiler/core/lux_core_helpers.nim
+++ b/laser/lux_compiler/core/lux_core_helpers.nim
@@ -11,7 +11,7 @@ import
 
 # ###########################################
 #
-#         Lux Core Helpers
+#         LuxNode unique identifiers
 #
 # ###########################################
 
@@ -27,3 +27,73 @@ proc genId*(): int =
     luxNodeRngCT.rand(high(int))
   else:
     luxNodeRngRT.rand(high(int))
+
+# ###########################################
+#
+#         LuxNode basic procs
+#
+# ###########################################
+
+const LuxExpr* = {IntLit..Domain}
+const LuxStmt* = {AffineFor, AffineIf}
+
+proc `[]`*(node: LuxNode, idx: int): var LuxNode =
+  node.children[idx]
+
+proc `[]=`*(node: LuxNode, idx: int, val: LuxNode) =
+  node.children[idx] = val
+
+proc len*(node: LuxNode): int =
+  node.children.len
+
+proc add*(node: LuxNode, val: LuxNode) =
+  node.children.add val
+
+proc add*(node: LuxNode, vals: openarray[LuxNode]) =
+  node.children.add vals
+
+iterator items*(node: LuxNode): LuxNode =
+  for val in node.children:
+    yield val
+
+# ###########################################
+#
+#         LuxNode tree constructions
+#
+# ###########################################
+
+proc newTree*(kind: LuxNodeKind, args: varargs[LuxNode]): LuxNode =
+  new result
+  result.id = genId()
+  result.kind = kind
+  result.children = @args
+
+proc newLux*(function: Function): LuxNode =
+  LuxNode(
+    id: genId(),
+    kind: Func, function: function
+  )
+
+proc newLux*(domain: Iter): LuxNode =
+  LuxNode(
+    id: genId(),
+    kind: Domain, iter: domain
+  )
+
+# We don't need genId for the following variant types
+
+proc newLux*(lit: int): LuxNode =
+  LuxNode(kind: IntLit, intVal: lit)
+
+proc newLux*(lit: float): LuxNode =
+  LuxNode(kind: FloatLit, floatVal: lit)
+
+proc newLux*(invariant: Invariant): LuxNode =
+  case invariant.kind:
+  of ikInt:
+    LuxNode(kind: IntParam, symParam: invariant.symbol)
+  of ikFLoat:
+    LuxNode(kind: FloatParam, symParam: invariant.symbol)
+
+proc newLux*(bopKind: BinaryOpKind): LuxNode =
+  LuxNode(kind: BinOpKind, bopKind: bopKind)

--- a/laser/lux_compiler/core/lux_core_helpers.nim
+++ b/laser/lux_compiler/core/lux_core_helpers.nim
@@ -34,8 +34,8 @@ proc genId*(): int =
 #
 # ###########################################
 
-const LuxExpr* = {IntLit..Domain}
-const LuxStmt* = {AffineFor, AffineIf}
+const LuxExpr* = {IntLit..DimSize}
+const LuxStmt* = {Statement..AffineIf}
 
 proc `[]`*(node: LuxNode, idx: int): var LuxNode =
   node.children[idx]

--- a/laser/lux_compiler/core/lux_core_helpers.nim
+++ b/laser/lux_compiler/core/lux_core_helpers.nim
@@ -27,33 +27,3 @@ proc genId*(): int =
     luxNodeRngCT.rand(high(int))
   else:
     luxNodeRngRT.rand(high(int))
-
-const ScalarExpr = {
-            IntImm, FloatImm, IntParam, FloatParam,
-            IntMut, FloatMut, IntLVal, FloatLVal,
-            BinOp,
-            Access, Shape, Domain
-          }
-
-func checkScalarExpr*(targetOp: string, input: LuxNode) =
-  # TODO - mapping LuxNode -> corresponding function
-  # for better errors as LuxNode are "low-level"
-  if input.kind notin ScalarExpr:
-    raise newException(
-      ValueError,
-      "Invalid scalar expression \"" & $input.kind & "\"\n" &
-      "Only the following LuxNodes are allowed:\n    " & $ScalarExpr &
-      "\nfor building a \"" & targetOp & "\" function."
-      # "\nOrigin: " & $node.lineInfo
-    )
-
-func checkMutable*(node: LuxNode) =
-  # TODO
-  discard
-
-func checkTensor*(node: LuxNode) =
-  if node.kind notin {InTensor, LValTensor, MutTensor}:
-    raise newException(
-      ValueError,
-      "Invalid tensor node \"" & $node.kind & "\""
-    )

--- a/laser/lux_compiler/core/lux_types.nim
+++ b/laser/lux_compiler/core/lux_types.nim
@@ -58,7 +58,7 @@ type
     Access      # Access a single element of a Tensor/Func
     DimSize     # Get the size of one of the Tensor/Func dimensions
 
-    # Extern Function Calls
+    # Function Calls
     ExternCall  # Extern function call like CPUInfo
 
     # ################### Statements #########################
@@ -125,7 +125,7 @@ type
     of BinOpKind:
       bopKind*: BinaryOpKind
     else:
-      children: seq[LuxNode]
+      children*: seq[LuxNode]
 
   ScheduleKind* = enum
     ScReduce
@@ -159,7 +159,7 @@ type
     symbol*: string
     start*, stop*, step*: LuxNode
 
-  InvariantKind = enum
+  InvariantKind* = enum
     ikInt
     ikFloat
 
@@ -183,6 +183,7 @@ type
     ##
     ## The first initial stage must define a default value
     ## on the whole domain
+    symbol*: string
     stages*: seq[Stage]
     schedule*: FunctionSchedule
     outputKind*: FuncOutputKind
@@ -194,6 +195,7 @@ type
     # assignation
     function*: Function
     params*: seq[LuxNode]
+    allow_mutation*: bool
 
   Stage* = ref object
     ## A unique definition of a function
@@ -220,51 +222,6 @@ type
 
   StageSchedule* = ref object
   FunctionSchedule* = ref object
-
-# ###########################################
-#
-#            Base procs and consts
-#
-# ###########################################
-
-const LuxExpr* = {IntLit..Domain}
-const LuxStmt* = {AffineFor, AffineIf}
-
-proc `[]`*(node: LuxNode, idx: int): var LuxNode =
-  node.children[idx]
-
-proc `[]=`*(node: LuxNode, idx: int, val: LuxNode) =
-  node.children[idx] = val
-
-proc len*(node: LuxNode): int =
-  node.children.len
-
-proc add*(node: LuxNode, val: LuxNode) =
-  node.children.add val
-
-proc newTree*(kind: LuxNodeKind, args: varargs[LuxNode]): LuxNode =
-  new result
-  result.kind = kind
-  result.children = @args
-
-proc newLux*(lit: int): LuxNode =
-  LuxNode(kind: IntLit, intVal: lit)
-
-proc newLux*(lit: float): LuxNode =
-  LuxNode(kind: FloatLit, floatVal: lit)
-
-proc newLux*(invariant: Invariant): LuxNode =
-  case invariant.kind:
-  of ikInt:
-    LuxNode(kind: IntParam, symParam: invariant.symbol)
-  of ikFLoat:
-    LuxNode(kind: FloatParam, symParam: invariant.symbol)
-
-proc newLux*(function: Function): LuxNode =
-  LuxNode(kind: Func, function: function)
-
-proc newLux*(domain: Iter): LuxNode =
-  LuxNode(kind: Domain, iter: domain)
 
 # ###########################################
 #

--- a/laser/lux_compiler/core/lux_types.nim
+++ b/laser/lux_compiler/core/lux_types.nim
@@ -183,10 +183,19 @@ type
     ##
     ## The first initial stage must define a default value
     ## on the whole domain
+    #
+    # For symbolic execution, the initial input tensors
+    # will be created as Function with no stages at all.
     symbol*: string
     stages*: seq[Stage]
     schedule*: FunctionSchedule
     outputKind*: FuncOutputKind
+
+  # ###########################################
+  #
+  #         Low-level data structures
+  #
+  # ###########################################
 
   Call* = ref object
     ## Object created when indexing a Function
@@ -195,7 +204,6 @@ type
     # assignation
     function*: Function
     params*: seq[LuxNode]
-    allow_mutation*: bool
 
   Stage* = ref object
     ## A unique definition of a function

--- a/laser/lux_compiler/dsl/primitives.nim
+++ b/laser/lux_compiler/dsl/primitives.nim
@@ -80,8 +80,6 @@ proc `[]`*(function: var Function, indices: varargs[Iter]): Call =
   for iter in indices:
     result.params.add newLux(iter)
 
-  result.allow_mutation = true
-
 proc `[]=`*(
         function: var Function,
         indices: varargs[Iter],
@@ -103,7 +101,7 @@ proc `[]=`*(
 
   let stageId = function.stages.len
   # if stageId = 0: assert that indices are the full function domain.
-
+  function.stages.setLen(stageId+1)
   new function.stages[stageId]
   for iter in indices:
     function.stages[stageId].params.add newLux(iter)

--- a/laser/lux_compiler/dsl/primitives.nim
+++ b/laser/lux_compiler/dsl/primitives.nim
@@ -7,8 +7,9 @@ import
   # Standard library
   macros,
   # Internal
-  ./primitives_helpers,
+  # ./primitives_helpers,
   ../../private/ast_utils,
+  ../core/[lux_types, lux_core_helpers],
   # Debug
   ../core/lux_print
 
@@ -18,79 +19,73 @@ import
 #
 # ###########################################
 
-proc dim_size*(t: LuxNode, axis: int): LuxNode =
-  LuxNode(
-    kind: DimSize,
-    tensor: t,
-    axis: axis
+proc dim_size*(function: Function, axis: int): LuxNode =
+  DimSize.newTree(
+    newLux function,
+    newLux axis
   )
 
 proc `+`*(a, b: LuxNode): LuxNode =
-  checkScalarExpr("Add", a)
-  checkScalarExpr("Add", b)
-  LuxNode(
-    id: genId(),
-    kind: BinOp, binOpKind: Add,
-    lhs: a, rhs: b
+  assert(a.kind in LuxExpr)
+  assert(b.kind in LuxExpr)
+  BinOp.newTree(
+    newLux Add,
+    a, b
   )
 
 proc `*`*(a, b: LuxNode): LuxNode =
-  checkScalarExpr("Mul", a)
-  checkScalarExpr("Mul", b)
-  LuxNode(
-    id: genId(),
-    kind: BinOp, binOpKind: Mul,
-    lhs: a, rhs: b
+  assert(a.kind in LuxExpr)
+  assert(b.kind in LuxExpr)
+  BinOp.newTree(
+    newLux Mul,
+    a, b
   )
 
 proc `*`*(a: LuxNode, b: SomeInteger): LuxNode =
-  checkScalarExpr("Mul", a)
-  LuxNode(
-      id: genId(),
-      kind: BinOp, binOpKind: Mul,
-      lhs: a,
-      rhs: LuxNode(kind: IntImm, intVal: b)
-    )
-
-proc `+=`*(a: var LuxNode, b: LuxNode) =
-  checkScalarExpr("In-place addition", b)
-  checkMutable(a)
-
-  # If LHS does not have a memory location, attribute one
-  if a.kind notin {MutTensor, LValTensor, MutAccess}:
-    lvalify(a)
-
-  # Then create the new node
-  var upd_a = LuxNode(id: genId())
-  upd_a.kind = a.kind
-  upd_a.symLVal = a.symLVal
-  upd_a.version = a.version + 1
-  upd_a.prev_version = assign(
-    lhs = a,
-    rhs = a + b
+  assert(a.kind in LuxExpr)
+  assert(b.kind in LuxExpr)
+  BinOp.newTree(
+    newLux Add,
+    a, newLux b
   )
 
-  # And swap it
-  a = upd_a
+proc `+=`*(a: var LuxNode, b: LuxNode) =
+  discard
 
-proc `[]`*(t: Function, indices: varargs[untyped]): untyped =
-  ## Access a tensor
+proc `[]`*(function: Function, indices: varargs[Iter]): Call =
+  ## Access a tensor/function
   ## For example
   ##   - A[i, j, k] on a rank 3 tensor
   ##   - A[0, i+j] on a rank 2 tensor (matrix)
   # TODO
-  # Handle the "_" joker for whole dimension
+  # - Handle the "_" joker for whole dimension
+  # - Handle combinations of Iter, LuxNodes, IntParams and literals
+  # - Get a friendly function symbol
+  new result
+  result.function = function
+  for iter in indices:
+    result.params.add newLux(iter)
 
-
-proc `[]`*(t: var Function, indices: varargs[untyped]): untyped =
-  ## Access a tensor
+proc `[]`*(function: var Function, indices: varargs[Iter]): Call =
+  ## Access a tensor/function
   ## For example
   ##   - A[i, j, k] on a rank 3 tensor
   ##   - A[0, i+j] on a rank 2 tensor (matrix)
   # TODO
-  # Handle the "_" joker for whole dimension
+  # - Handle the "_" joker for whole dimension
+  # - Handle combinations of Iter, LuxNodes, IntParams and literals
+  # - Get a friendly function symbol
+  new result
+  result.function = function
+  for iter in indices:
+    result.params.add newLux(iter)
 
-proc `[]=`*(t: var Function, indicesAndExpr: varargs[untyped]): untyped =
+  result.allow_mutation = true
+
+proc `[]=`*(
+        function: var Function,
+        indices: varargs[Iter],
+        expression: LuxNode) =
   ## Mutate a Func/tensor element
   ## at specified indices
   ##
@@ -100,4 +95,25 @@ proc `[]=`*(t: var Function, indicesAndExpr: varargs[untyped]): untyped =
   ##
   ## Used for A[i, j] = foo(i, j)
   # TODO
-  # Handle the "_" joker for whole dimension
+  # - Handle the "_" joker for whole dimension
+  # - Handle combinations of Iter, LuxNodes, IntParams and literals
+  # - Get a friendly function symbol
+  if function.isNil:
+    new function
+
+  let stageId = function.stages.len
+  # if stageId = 0: assert that indices are the full function domain.
+
+  new function.stages[stageId]
+  for iter in indices:
+    function.stages[stageId].params.add newLux(iter)
+  function.stages[stageId].definition = expression
+
+converter toLuxNode*(call: Call): LuxNode =
+  # Implicit conversion of function/tensor indexing
+  # to allow seamless:
+  # A[i,j] = myParam + B[i,j]
+  result = Access.newTree(
+    newLux call.function
+  )
+  result.add call.params

--- a/laser/lux_compiler/frontend/lux_frontend.nim
+++ b/laser/lux_compiler/frontend/lux_frontend.nim
@@ -35,58 +35,62 @@ macro generate*(ast_routine: typed, signature: untyped): untyped =
   ## The procs generated are specialized (they cannot be generic)
   ## but the same base ast_routine can be reused to generate all
   ## the desired specialized procs.
-
-  # TODO: remove the need for ast_routine for symbol resolution
+  ##
+  ## The name of the generated proc does not need to be the same
+  ## as the symbolic proc.
+  ##
+  ## The signature can include pragmas like {.exportc.}
 
   result = newStmtList()
 
-  # # TODO: canonicalize signature
-  # let formalParams = signature[0][3]
-  # let ast = ast_routine.resolveASToverload(formalParams)
+  # TODO: canonicalize signature
+  let formalParams = signature[0][3]
+  let ast = ast_routine.resolveASToverload(formalParams)
 
-  # # Get the routine signature
-  # let sig = ast.getImpl[3]
-  # sig.expectKind(nnkFormalParams)
+  # Get the routine signature
+  let sig = ast.getImpl[3]
+  sig.expectKind(nnkFormalParams)
 
-  # # Get all inputs
-  # var inputSyms: seq[NimNode]
-  # for idx_identdef in 1 ..< sig.len:
-  #   let identdef = sig[idx_identdef]
-  #   doAssert identdef[^2].eqIdent"LuxNode"
-  #   identdef[^1].expectKind(nnkEmpty)
-  #   for idx_ident in 0 .. identdef.len-3:
-  #     inputSyms.add genSym(nskLet, $identdef[idx_ident] & "_")
+  # Get all inputs
+  var inputSyms: seq[NimNode]
+  for idx_identdef in 1 ..< sig.len:
+    let identdef = sig[idx_identdef]
+    doAssert identdef[^2].eqIdent"Function" or
+               identdef[^2].eqIdent"Invariant"
+    identdef[^1].expectKind(nnkEmpty)
+    for idx_ident in 0 .. identdef.len-3:
+      inputSyms.add genSym(nskLet, $identdef[idx_ident] & "_")
 
-  # # Symbolic execution statement
-  # var outputSyms: NimNode
-  # var symExecStmt = newStmtList()
-  # symbolicExecStmt(
-  #     ast,
-  #     inputSyms,
-  #     hasOut = sig[0].kind != nnkEmpty,
-  #     outputSyms,
-  #     symExecStmt
-  #   )
+  # Symbolic execution statement
+  var outputSyms: NimNode
+  var symExecStmt = newStmtList()
+  symbolicExecStmt(
+      ast,
+      inputSyms,
+      hasOut = sig[0].kind != nnkEmpty,
+      outputSyms,
+      symExecStmt
+    )
 
-  # # Collect all the input/output idents
-  # var io = inputSyms
-  # case sig[0].kind
-  # of nnkEmpty:
-  #   discard
-  # of nnkTupleTy:
-  #   var idx = 0
-  #   for identdef in sig[0]:
-  #     for idx_ident in 0 .. identdef.len-3:
-  #       io.add nnkBracketExpr.newTree(
-  #         outputSyms[0],
-  #         newLit idx
-  #       )
-  #       inc idx
-  # else:
-  #   io.add outputSyms
+  # Collect all the input/output idents
+  var io = inputSyms
+  case sig[0].kind
+  of nnkEmpty:
+    discard
+  of nnkTupleTy:
+    var idx = 0
+    for identdef in sig[0]:
+      for idx_ident in 0 .. identdef.len-3:
+        io.add nnkBracketExpr.newTree(
+          outputSyms[0],
+          newLit idx
+        )
+        inc idx
+  else:
+    io.add outputSyms
 
-  # # Call the compilation macro
-  # result.add symExecStmt
+  # Call the compilation macro
+  result.add symExecStmt
   # result.add quote do:
   #   compile(`io`, `signature`)
 

--- a/laser/lux_compiler/frontend/lux_frontend.nim
+++ b/laser/lux_compiler/frontend/lux_frontend.nim
@@ -12,7 +12,7 @@ import
   ./lux_sigmatch,
   ./lux_symbolic_exec
 
-from ../backend/lux_backend import compile
+# from ../backend/lux_backend import compile
 
 # ###########################################
 #
@@ -40,54 +40,54 @@ macro generate*(ast_routine: typed, signature: untyped): untyped =
 
   result = newStmtList()
 
-  # TODO: canonicalize signature
-  let formalParams = signature[0][3]
-  let ast = ast_routine.resolveASToverload(formalParams)
+  # # TODO: canonicalize signature
+  # let formalParams = signature[0][3]
+  # let ast = ast_routine.resolveASToverload(formalParams)
 
-  # Get the routine signature
-  let sig = ast.getImpl[3]
-  sig.expectKind(nnkFormalParams)
+  # # Get the routine signature
+  # let sig = ast.getImpl[3]
+  # sig.expectKind(nnkFormalParams)
 
-  # Get all inputs
-  var inputSyms: seq[NimNode]
-  for idx_identdef in 1 ..< sig.len:
-    let identdef = sig[idx_identdef]
-    doAssert identdef[^2].eqIdent"LuxNode"
-    identdef[^1].expectKind(nnkEmpty)
-    for idx_ident in 0 .. identdef.len-3:
-      inputSyms.add genSym(nskLet, $identdef[idx_ident] & "_")
+  # # Get all inputs
+  # var inputSyms: seq[NimNode]
+  # for idx_identdef in 1 ..< sig.len:
+  #   let identdef = sig[idx_identdef]
+  #   doAssert identdef[^2].eqIdent"LuxNode"
+  #   identdef[^1].expectKind(nnkEmpty)
+  #   for idx_ident in 0 .. identdef.len-3:
+  #     inputSyms.add genSym(nskLet, $identdef[idx_ident] & "_")
 
-  # Symbolic execution statement
-  var outputSyms: NimNode
-  var symExecStmt = newStmtList()
-  symbolicExecStmt(
-      ast,
-      inputSyms,
-      hasOut = sig[0].kind != nnkEmpty,
-      outputSyms,
-      symExecStmt
-    )
+  # # Symbolic execution statement
+  # var outputSyms: NimNode
+  # var symExecStmt = newStmtList()
+  # symbolicExecStmt(
+  #     ast,
+  #     inputSyms,
+  #     hasOut = sig[0].kind != nnkEmpty,
+  #     outputSyms,
+  #     symExecStmt
+  #   )
 
-  # Collect all the input/output idents
-  var io = inputSyms
-  case sig[0].kind
-  of nnkEmpty:
-    discard
-  of nnkTupleTy:
-    var idx = 0
-    for identdef in sig[0]:
-      for idx_ident in 0 .. identdef.len-3:
-        io.add nnkBracketExpr.newTree(
-          outputSyms[0],
-          newLit idx
-        )
-        inc idx
-  else:
-    io.add outputSyms
+  # # Collect all the input/output idents
+  # var io = inputSyms
+  # case sig[0].kind
+  # of nnkEmpty:
+  #   discard
+  # of nnkTupleTy:
+  #   var idx = 0
+  #   for identdef in sig[0]:
+  #     for idx_ident in 0 .. identdef.len-3:
+  #       io.add nnkBracketExpr.newTree(
+  #         outputSyms[0],
+  #         newLit idx
+  #       )
+  #       inc idx
+  # else:
+  #   io.add outputSyms
 
-  # Call the compilation macro
-  result.add symExecStmt
-  result.add quote do:
-    compile(`io`, `signature`)
+  # # Call the compilation macro
+  # result.add symExecStmt
+  # result.add quote do:
+  #   compile(`io`, `signature`)
 
-  # echo result.toStrlit
+  # # echo result.toStrlit

--- a/laser/lux_compiler/frontend/lux_symbolic_exec.nim
+++ b/laser/lux_compiler/frontend/lux_symbolic_exec.nim
@@ -17,19 +17,22 @@ import
 #
 # ###########################################
 
-# proc inputTensor(paramId: int): LuxNode =
-#   LuxNode(
-#     id: genId(),
-#     kind: InTensor, symId: paramId
-#   )
+proc inputFunction(funcIdent: NimNode): NimNode =
+  nnkObjConstr.newTree(
+    ident"Function",
+    nnkExprColonExpr.newTree(
+      ident"symbol",
+      newLit $funcIdent
+    )
+  )
 
 proc symbolicExecStmt*(ast: NimNode, inputSyms: seq[NimNode], hasOut: bool, outputSyms, stmts: var NimNode) =
   # Allocate inputs
-  # for i, in_ident in inputSyms:
-  #   stmts.add newLetStmt(
-  #     ct(in_ident),
-  #     newCall(bindSym"inputTensor", newLit i)
-  #   )
+  for i, in_ident in inputSyms:
+    stmts.add newLetStmt(
+      ct(in_ident),
+      inputFunction(in_ident)
+    )
 
   # Call the AST routine
   let call = newCall(ast, inputSyms)

--- a/laser/lux_compiler/frontend/lux_symbolic_exec.nim
+++ b/laser/lux_compiler/frontend/lux_symbolic_exec.nim
@@ -17,19 +17,19 @@ import
 #
 # ###########################################
 
-proc inputTensor(paramId: int): LuxNode =
-  LuxNode(
-    id: genId(),
-    kind: InTensor, symId: paramId
-  )
+# proc inputTensor(paramId: int): LuxNode =
+#   LuxNode(
+#     id: genId(),
+#     kind: InTensor, symId: paramId
+#   )
 
 proc symbolicExecStmt*(ast: NimNode, inputSyms: seq[NimNode], hasOut: bool, outputSyms, stmts: var NimNode) =
   # Allocate inputs
-  for i, in_ident in inputSyms:
-    stmts.add newLetStmt(
-      ct(in_ident),
-      newCall(bindSym"inputTensor", newLit i)
-    )
+  # for i, in_ident in inputSyms:
+  #   stmts.add newLetStmt(
+  #     ct(in_ident),
+  #     newCall(bindSym"inputTensor", newLit i)
+  #   )
 
   # Call the AST routine
   let call = newCall(ast, inputSyms)

--- a/laser/lux_compiler/lux_dsl.nim
+++ b/laser/lux_compiler/lux_dsl.nim
@@ -52,7 +52,7 @@ when isMainModule:
     bar[i, j] = a[i, j] + b[i, j] + c[i, j]
 
     # Update result
-    result.bar = bar
+    result = bar
 
   generate foobar:
     proc foobar(a: Tensor[float32], b, c: Tensor[float32]): tuple[bar: Tensor[float32]]
@@ -68,5 +68,5 @@ when isMainModule:
          [float32 3, 3, 3],
          [float32 3, 3, 3]].toTensor()
 
-  let r = foobar(u, v, w)
-  echo r
+  # let r = foobar(u, v, w)
+  # echo r

--- a/laser/lux_compiler/lux_dsl.nim
+++ b/laser/lux_compiler/lux_dsl.nim
@@ -7,7 +7,7 @@ import
   ./frontend/lux_frontend,
   ./dsl/primitives
 
-from ./core/lux_types import LuxNode
+from ./core/lux_types import Iter, Invariant, Function
 
 # ###########################
 #
@@ -40,19 +40,14 @@ when isMainModule:
     assert idx.len == 2
     t.storage.raw_buffer[idx[0] * t.strides[0] + idx[1] * t.strides[1]] = val
 
+  proc foobar(a, b, c: Function): Function =
 
-  # We intentionally have a tricky non-canonical function signature
-  proc foobar(a: LuxNode, b, c: LuxNode): tuple[bar: LuxNode] =
-
-    # Domain
-    var i, j: LuxNode
-    newLuxIterDomain(i, 0, a.shape(0))
-    newLuxIterDomain(j, 0, a.shape(1))
+    # Iteration Domain
+    var i, j: Iter
 
     # Avoid in-place update of implicit result ref address
     # https://github.com/nim-lang/Nim/issues/11637
-    var bar: LuxNode
-    newLuxMutTensor(bar)
+    var bar: Function
 
     bar[i, j] = a[i, j] + b[i, j] + c[i, j]
 


### PR DESCRIPTION
This is the third overhault of Lux AST (and hopefully the last).

History:

V1 introduced in https://github.com/numforge/laser/commit/a88a8581f0e2a72332efbfa8b6d60d9a33f21ea2 could only do elementwise operations with a proof of concept vectorization for 1 selected SIMD architecture (SSE, AVX, ...)

V2 introduced in https://github.com/numforge/laser/pull/29, split Lux into a high-level DSL, a frontend compiler that could symbolically execute that DSL, pass the produced trace to a backend compiler which would run lowering passes (to build loops from the tensors iteration domain) and then generate code.

The implementation highlighted a couple of issues in the design:

**composability** was bad because both the input `A: InTensor, B: InTensor` and their elements `A[i,j]` where of the same type, which means doing `A + B` and `A[i,j] + B[i,j]` would use the same proc instead of proc overloading.

The **code generation** part is tricky because of the lack of `statement list`, for example the `AffineFor` node had to return the nested lval symbol. This would have caused issue for implementing the loop fusion pass.

The **user ergonomics** was bad due to needing various initialization procs for domains, tensors and parameters.

Now instead of the following
```Nim
proc foobar(a: LuxNode, b, c: LuxNode): LuxNode =
  var i, j: LuxNode	
  newLuxIterDomain(i, 0, a.shape(0))	
  newLuxIterDomain(j, 0, a.shape(1))	

  var bar: LuxNode
  newLuxMutTensor(bar)

  bar[i, j] = a[i, j] + b[i, j] + c[i, j]
  
  result = bar
```
We can use this
```Nim
proc foobar(a: LuxNode, b, c: LuxNode): LuxNode =
  var i, j: LuxNode	
  var bar: LuxNode

  bar[i, j] = a[i, j] + b[i, j] + c[i, j]
  
  result = bar
```

The **developer ergonomics** is significantly improved with variant types now working like Nim or Lisp: almost everything is a `seq[LuxNode]`, there is no need to remember single-use field names and AST traversal is more generics, and AST is easier to extend with no need to think of new field names to avoid collision. Also since it works like Nim AST, it's familiar to Nim devs (or would be helpful to learn Nim macros)

InTensors, MutTensors, LValTensors, MutFloats/LValFloats, MutInt, LValInt have all been replaced by the `Function` type. Like before it is keeping version information in a persistent data-structure, but instead of a tree structure it appends new versions to a sequence. Furthermore in Lux AST v2, we were forced to store AffineFor and other statements in the `previous_version` field. With the AST changes and the introduction of a StatementList this shouldn't be needed anymore.

Lastly, users were exposed to the low-level concept of LuxNode.